### PR TITLE
Defer the call to setupClient to allow the config to be changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 composer.phar
 /vendor/
+.idea
 
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/src/Client.php
+++ b/src/Client.php
@@ -37,6 +37,10 @@ class Client
 
     protected $recordFileName = 'saveState.json';
 
+    private $booted = false;
+
+    private $options = [];
+
     private $shutdownRegistered = false;
 
     /**
@@ -66,7 +70,7 @@ class Client
             unset($options['recordFileName']);
         }
 
-        $this->setupClient($options);
+        $this->options = $options;
         $this->registerShutdown();
     }
 
@@ -123,6 +127,10 @@ class Client
 
     protected function doRequest($method, $uri = null, array $options = [], $async = false)
     {
+        if (!$this->booted) {
+            $this->setupClient($this->options);
+        }
+
         if ($this->mode === self::PLAYBACK) {
             $response = array_shift($this->callList);
         } else {
@@ -153,6 +161,8 @@ class Client
         }
 
         $this->client = new GuzzleClient($options);
+
+        $this->booted = true;
     }
 
     protected function getRecordFilePath()


### PR DESCRIPTION
Use case here is to be able to change the config (specifically `recordFileName`) on a per test basis allowing other pre-recorded requests to be switched in, rather than having to define multiple test clients.

For example in a Symfony `KernelTestCase`:
```php
$client = $container->get('test.guzzle_client.instance');

$prop = (new \ReflectionObject($client))->getProperty('recordFileName');
$prop->setAccessible(true);
$prop->setValue($client, 'alternative_response_file.json');
```

