### PR TITLE
Capture server response if available during exception recording

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 composer.phar
 /vendor/
-
+.idea
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-# composer.lock
+composer.lock

--- a/src/Client.php
+++ b/src/Client.php
@@ -285,9 +285,9 @@ class Client implements ClientInterface
                         'body' => $response->getRequest()->getBody()->__toString()
                     ],
                     'response' => [
-                        'statusCode' => $response->getResponse() ? $response->getResponse()->getStatusCode() : 500,
-                        'headers' => $response->getResponse() ? $response->getResponse()->getHeaders() : [],
-                        'body' => $response->getResponse() ? $response->getResponse()->getBody()->__toString() : ''
+                        'statusCode' => $response->hasResponse() ? $response->getResponse()->getStatusCode() : 500,
+                        'headers' => $response->hasResponse() ? $response->getResponse()->getHeaders() : [],
+                        'body' => $response->hasResponse() ? $response->getResponse()->getBody()->__toString() : ''
                     ]
                 ];
             } else {
@@ -328,7 +328,11 @@ class Client implements ClientInterface
                     $item['response']['body']
                 );
 
-                if (is_a($errorClass, BadResponseException::class, true)) {
+                if (
+                    is_a($errorClass, BadResponseException::class, true)
+                    ||
+                    is_subclass_of($errorClass, BadResponseException::class, true)
+                ) {
                     $mockedResponses[] = new $errorClass($item['errorMessage'], $request, $response);
                 } else {
                     $mockedResponses[] = new $errorClass($item['errorMessage'], $request);


### PR DESCRIPTION
Guzzle\BadResponseException expects a Response object and will trigger an E_USER_DEPRECATED notice if not set. This patch captures the response information as a new sub-array that can be turned back into a Response object and passed to the BadResponseException constructor preserving the server response information. If no response is set, defaults are used instead.